### PR TITLE
Adding Outputs Json Parser

### DIFF
--- a/smoke_test.yaml
+++ b/smoke_test.yaml
@@ -109,3 +109,19 @@ contracts:
   method: GET
 
   http_code_is: 302
+
+- name: get_output_variable
+  path: "/posts/2"
+  method: GET
+
+  outputs:
+    userId: "JSON.userId"
+
+  http_code_is: 200
+
+- name: test_input_variable
+  path: "/users/::userId::"
+  method: GET
+
+  http_code_is: 200
+  response_body_contains: "\"id\": 1"


### PR DESCRIPTION
Hello @colindickson,

I wanted to add a new feature that allow me to get some variable in the response of one request to inject it in another request. Like a local defined by the response of the body.

So I changed a little bit the code to add a new field "outputs".
That allow me to do so.

I added 2 more tests on the yaml file. So you can test it with the command line :
go run main.go -v -f ./smoke_test.yaml -u http://jsonplaceholder.typicode.com -p 80

What it will do is go to :grinning: 
- https://jsonplaceholder.typicode.com/posts/2

get the userId, and then inject if on the next request :grinning: 
https://jsonplaceholder.typicode.com/users/::userId:: (should be a 1)

If you like this idea, I will continue working on it, adding unit tests, and json tests to.