### PR TITLE
feat: Match body with regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The structure of a contract element is a map with the following elements:
 - `headers`: map of header values to add to the http request (optional)
 - `locals`: map of variables specific to this test case. will override the global values
 - `http_code_is`: integer representing the expected http code in the result
-- `response_body_contains`: string representing an expected value within the resulting response body 
+- `response_body_contains`: string representing an expected value within the resulting response body (Can be a regexp begining by r/ example "r/[0-9]*" )
 
 See the `smoke_test.json` and `smoke_test.yaml` files for examples. 
 

--- a/smoke_test.json
+++ b/smoke_test.json
@@ -161,6 +161,13 @@
       "method": "GET",
 
       "response_body_contains": "r/[1-5]{5}"
+    },
+    {
+      "name": "httpbin_get_body_regexp_not_compiling",
+      "path": "/get?foo=r/[1-a{5}!",
+      "method": "GET",
+
+      "response_body_contains": "r/[1-a{5}"
     }
   ]
 }

--- a/smoke_test.json
+++ b/smoke_test.json
@@ -154,6 +154,13 @@
 
       "http_code_is": 200,
       "response_body_contains": "bar"
-    }     
+    },
+    {
+      "name": "httpbin_get_body_regexp",
+      "path": "/get?foo=12345!",
+      "method": "GET",
+
+      "response_body_contains": "r/[1-5]{5}"
+    }
   ]
 }

--- a/smoke_test.yaml
+++ b/smoke_test.yaml
@@ -143,3 +143,9 @@ contracts:
   method: GET
 
   response_body_contains: "r/[1-5]{5}"
+
+- name: httpbin_get_body_regexp_not_compiling
+  path: "/get?foo=r/[1-a{5}!"
+  method: GET
+
+  response_body_contains: "r/[1-a{5}"

--- a/smoke_test.yaml
+++ b/smoke_test.yaml
@@ -137,3 +137,9 @@ contracts:
 
   http_code_is: 200
   response_body_contains: "bar"
+
+- name: httpbin_get_body_regexp
+  path: "/get?foo=12345!"
+  method: GET
+
+  response_body_contains: "r/[1-5]{5}"

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/fatih/color"
@@ -193,9 +194,18 @@ func validateHTTPCode(contract Contract, resp *http.Response) error {
 
 func validateResponseBody(contract Contract, body []byte) error {
 	if contract.ExpectedResponseBody != "" {
-		if !strings.Contains(string(body), contract.ExpectedResponseBody) {
-			return fmt.Errorf("expected response not found in the body")
+		if !strings.HasPrefix(contract.ExpectedResponseBody, "r/") {
+			if !strings.Contains(string(body), contract.ExpectedResponseBody) {
+				return fmt.Errorf("expected response not found in the body")
+			}
+		} else {
+			expectedRegexp := contract.ExpectedResponseBody[2:]
+			re := regexp.MustCompile(expectedRegexp)
+			if !re.MatchString(string(body)) {
+				return fmt.Errorf("expected regexp not found in the body")
+			}
 		}
+
 	}
 
 	return nil

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -199,7 +199,7 @@ func validateResponseBody(contract Contract, body []byte) error {
 			expectedRegexp := contract.ExpectedResponseBody[2:]
 			re, err := regexp.Compile(expectedRegexp)
 			if err == nil {
-				if !re.MatchString(string(body)) {
+				if !re.Match(body) {
 					return fmt.Errorf("expected regexp not found in the body")
 				}
 				return nil

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -1,6 +1,7 @@
 package tester
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -194,16 +195,19 @@ func validateHTTPCode(contract Contract, resp *http.Response) error {
 
 func validateResponseBody(contract Contract, body []byte) error {
 	if contract.ExpectedResponseBody != "" {
-		if !strings.HasPrefix(contract.ExpectedResponseBody, "r/") {
-			if !strings.Contains(string(body), contract.ExpectedResponseBody) {
-				return fmt.Errorf("expected response not found in the body")
-			}
-		} else {
+		if strings.HasPrefix(contract.ExpectedResponseBody, "r/") {
 			expectedRegexp := contract.ExpectedResponseBody[2:]
-			re := regexp.MustCompile(expectedRegexp)
-			if !re.MatchString(string(body)) {
-				return fmt.Errorf("expected regexp not found in the body")
+			re, err := regexp.Compile(expectedRegexp)
+			if err == nil {
+				if !re.MatchString(string(body)) {
+					return fmt.Errorf("expected regexp not found in the body")
+				}
+				return nil
 			}
+		}
+
+		if !bytes.Contains(body, []byte(contract.ExpectedResponseBody)) {
+			return fmt.Errorf("expected response not found in the body")
 		}
 
 	}


### PR DESCRIPTION
This feature allow the user to test if the body matches a regular expression.
By adding a prefix r/ :

example that check if there are at least one number on the body :
```
response_body_contains: "r/[0-9]{1}"
```