### PR TITLE
feat: Validate by Header Response

### DIFF
--- a/smoke_test.json
+++ b/smoke_test.json
@@ -168,6 +168,20 @@
       "method": "GET",
 
       "response_body_contains": "r/[1-a{5}"
+    },
+    {
+      "name": "httpbin_verify_response_header",
+      "path": "/response-headers?My-Header=found",
+      "method": "GET",
+
+      "response_headers_is": {"My-Header": "found"}
+    },
+    {
+      "name": "httpbin_verify_many_response_header",
+      "path": "/response-headers?My-Header=found&My-Header2=foundToo",
+      "method": "GET",
+
+      "response_headers_is": {"My-Header": "found", "My-Header2": "foundToo"}
     }
   ]
 }

--- a/smoke_test.yaml
+++ b/smoke_test.yaml
@@ -149,3 +149,18 @@ contracts:
   method: GET
 
   response_body_contains: "r/[1-a{5}"
+
+- name: httpbin_verify_response_header
+  path: "/response-headers?My-Header=found"
+  method: GET
+
+  response_headers_is: 
+    My-Header: "found"
+
+- name: httpbin_verify_many_response_header
+  path: "/response-headers?My-Header=found&My-Header2=foundToo"
+  method: GET
+
+  response_headers_is: 
+    My-Header: "found"
+    My-Header2: "foundToo"


### PR DESCRIPTION
Hello @colindickson I wanted to be able to validate the response header.

For example :
In a request I can get two different content-type dependning of some parameters.
And I want to a be able o validate the Headers I receive.

So I have coded a simple code that evaluate if the header is present, and if the value is the good one.