### PR TITLE
feat: add the possibility to check if the body matches many expected strings

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func prepareResponseBody(t *tester.Test) {
 	if t != nil && t.Contracts != nil && len(t.Contracts) > 0 {
 		for _, c := range t.Contracts {
 			if c.ExpectedResponseBody != "" {
-				c.ExpectedResponse = append(c.ExpectedResponse, c.ExpectedResponseBody)
+				c.ExpectedResponses = append(c.ExpectedResponses, c.ExpectedResponseBody)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -43,6 +43,8 @@ func main() {
 		os.Exit(2)
 	}
 
+	prepareResponseBody(&t)
+
 	url := opts.URL
 	if opts.Port != 0 {
 		url = fmt.Sprintf("%s:%d", url, opts.Port)
@@ -80,4 +82,15 @@ func unmarshal(filename string, in []byte, out interface{}) error {
 	}
 
 	return unmarshalError
+}
+
+// In order to keep retro compatibility with ExpectedResponseBody, and at the same time introducing multiple response check with ExpectedResponse
+func prepareResponseBody(t *tester.Test) {
+	if t != nil && t.Contracts != nil && len(t.Contracts) > 0 {
+		for _, c := range t.Contracts {
+			if c.ExpectedResponseBody != "" {
+				c.ExpectedResponse = append(c.ExpectedResponse, c.ExpectedResponseBody)
+			}
+		}
+	}
 }

--- a/smoke_test.json
+++ b/smoke_test.json
@@ -182,6 +182,22 @@
       "method": "GET",
 
       "response_headers_is": {"My-Header": "found", "My-Header2": "foundToo"}
+    },
+    {
+      "name": "httpbin_get_body_multiple",
+      "path": "/get?foo=hello!",
+      "method": "GET",
+
+
+      "response_contains": ["hello", "foo", "!"]
+    },
+    {
+      "name": "httpbin_get_response_multiple",
+      "path": "/get?foo=hello!",
+      "method": "GET",
+
+      "response_body_contains": "hello",
+      "response_contains": ["foo", "!"]
     }
   ]
 }

--- a/smoke_test.yaml
+++ b/smoke_test.yaml
@@ -164,3 +164,22 @@ contracts:
   response_headers_is: 
     My-Header: "found"
     My-Header2: "foundToo"
+
+- name: httpbin_get_body_multiple
+  path: "/get?foo=hello!"
+  method: GET
+
+  response_body_contains: hello
+  response_contains:
+    - foo
+    - !
+
+- name: httpbin_get_response_multiple
+  path: "/get?foo=hello!"
+  method: GET
+
+  response_contains:
+    - hello
+    - foo
+    - !
+

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -39,7 +39,7 @@ type Contract struct {
 
 	ExpectedHTTPCode     int               `json:"http_code_is" yaml:"http_code_is"`
 	ExpectedResponseBody string            `json:"response_body_contains" yaml:"response_body_contains"`
-	ExpectedResponse     []string 		   `json:"response_contains" yaml:"response_contains"`
+	ExpectedResponses    []string 		   `json:"response_contains" yaml:"response_contains"`
 	ExpectedHeaders      map[string]string `json:"response_headers_is" yaml:"response_headers_is"`
 }
 
@@ -143,7 +143,7 @@ func (runner *Runner) validateContract(contract Contract) (err error) {
 		}
 	}
 
-	if len(contract.ExpectedResponse) > 0 || (contract.Outputs != nil && len(contract.Outputs) > 0) {
+	if len(contract.ExpectedResponses) > 0 || (contract.Outputs != nil && len(contract.Outputs) > 0) {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err
@@ -203,11 +203,11 @@ func validateHTTPCode(contract Contract, resp *http.Response) error {
 }
 
 func validateResponseBody(contract Contract, body []byte) error {
-	if len(contract.ExpectedResponse) == 0 {
+	if len(contract.ExpectedResponses) == 0 {
 		return nil
 	}
 	
-	for _, r := range contract.ExpectedResponse {
+	for _, r := range contract.ExpectedResponses {
 		// check if it is a regexp
 		if strings.HasPrefix(r, "r/") {
 			expectedRegexp := r[2:]


### PR DESCRIPTION
A new array field response_contains, can contains many string to check

To stay retro compatible with response_body_contains, we add the response_body_contains to the response_contains array.

I don't really like what the function to ensure the retro compatibility prepareResponseBody
Do you think we can add it elsewhere ?