### PR TITLE
Fix: Bug on appending response_body_contains

### DIFF
--- a/internal/tester/tester.go
+++ b/internal/tester/tester.go
@@ -74,12 +74,12 @@ func (t *Test) init() {
 		return
 	}
 
-	for _, c := range t.Contracts {
-		if c.ExpectedResponseBody == "" {
+	for i := range t.Contracts {
+		if t.Contracts[i].ExpectedResponseBody == "" {
 			continue
 		}
 
-		c.ExpectedResponses = append(c.ExpectedResponses, c.ExpectedResponseBody)
+		t.Contracts[i].ExpectedResponses = append(t.Contracts[i].ExpectedResponses, t.Contracts[i].ExpectedResponseBody)
 	}
 }
 


### PR DESCRIPTION
As I was using the value on the for, and not the reference, the append was not done on global context (Sorry)
It's fixed now.