### PR TITLE
check if flag parsing error is errhelp

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,10 +22,12 @@ var opts struct {
 func main() {
 	_, err := flags.Parse(&opts)
 	if err != nil {
-		if ferr, ok := err.(*flags.Error); ok && ferr.Type == flags.ErrHelp {
-			os.Exit(0)
+		ferr, ok := err.(*flags.Error)
+		
+		if !ok || (ok && ferr.Type != flags.ErrHelp) {
+			fmt.Fprintf(os.Stderr, err.Error())
 		}
-		fmt.Fprintf(os.Stderr, err.Error())
+
 		os.Exit(2)
 	}
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,9 @@ var opts struct {
 func main() {
 	_, err := flags.Parse(&opts)
 	if err != nil {
+		if ferr, ok := err.(*flags.Error); ok && ferr.Type == flags.ErrHelp {
+			os.Exit(0)
+		}
 		fmt.Fprintf(os.Stderr, err.Error())
 		os.Exit(2)
 	}


### PR DESCRIPTION
The command help is printed twice: first in stdin and later in stderr.

This merge request is to "fix" that.

but also waiting for comments, about the correct exit value.